### PR TITLE
Bootstrap addon: Added sm class selector on init functon

### DIFF
--- a/src/addons/bootstrap/jquery.smartmenus.bootstrap.js
+++ b/src/addons/bootstrap/jquery.smartmenus.bootstrap.js
@@ -14,7 +14,7 @@
 	$.extend($.SmartMenus.Bootstrap = {}, {
 		init: function() {
 			// init all navbars that don't have the "data-sm-skip" attribute set
-			var $navbars = $('ul.navbar-nav:not([data-sm-skip])');
+			var $navbars = $('ul.sm.navbar-nav:not([data-sm-skip])');
 			$navbars.each(function() {
 				var $this = $(this),
 					obj = $this.data('smartmenus');


### PR DESCRIPTION
Came across a problem where we had two different bootstrap menus and we only wanted to use smartmenu on one of them. Added '.sm' to the selector on the init function to solve this problem. Now only the ul.navbar specified with the sm class will be affected by the init function. And the navbar without the sm class will remain the same.

What do you think?