### PR TITLE
add option to enable/disable mouse over event

### DIFF
--- a/src/jquery.smartmenus.js
+++ b/src/jquery.smartmenus.js
@@ -431,7 +431,7 @@
 				return $(this.getClosestMenu($a[0])).hasClass('mega-menu');
 			},
 			isTouchMode: function() {
-				return !mouse || this.isCollapsible();
+				return (!mouse || this.opts.noMouseOver) || this.isCollapsible();
 			},
 			itemActivate: function($a, focus) {
 				var $ul = $a.closest('ul'),
@@ -1215,6 +1215,7 @@
 		rightToLeftSubMenus:	false,		// right to left display of the sub menus (check the CSS for the sub indicators' position)
 		bottomToTopSubMenus:	false,		// bottom to top display of the sub menus
 		overlapControlsInIE:	true		// make sure sub menus appear on top of special OS controls in IE (i.e. SELECT, OBJECT, EMBED, etc.)
+		noMouseOver: false 					// set if th menu list will appear on mouse over event
 	};
 
 })(jQuery);


### PR DESCRIPTION
hi,
instead of use the code bellow: [(I found in your forum)](http://www.smartmenus.org/forums/topic/prevent-menu-from-expanding-on-hover/)
`$.SmartMenus.prototype.isTouchMode: function() {return true;} // activate touch mode permanently`
I made the default option *noMouseOver*, setting false by default, because most of users prefers mouseOver events (I tried to convince my customer, no success :-1:) 
and I updated the IsTouchMode function:
`isTouchMode: function() {return (!mouse || this.opts.noMouseOver) || this.isCollapsible();}`

works fine on Chrome 46 and 48,IE 11, EDGE, Firefox..

That's all, thanks for your patience and sorry about my poor english..

Best Regards,
Samuel