### PR TITLE
Apply data-sm-options on a per list basis

### DIFF
--- a/src/jquery.smartmenus.js
+++ b/src/jquery.smartmenus.js
@@ -1163,17 +1163,17 @@
 				}
 			});
 		}
-		// [data-sm-options] attribute on the root UL
-		var dataOpts = this.data('sm-options') || null;
-		if (dataOpts) {
-			try {
-				dataOpts = eval('(' + dataOpts + ')');
-			} catch(e) {
-				dataOpts = null;
-				alert('ERROR\n\nSmartMenus jQuery init:\nInvalid "data-sm-options" attribute value syntax.');
-			};
-		}
 		return this.each(function() {
+			// [data-sm-options] attribute on the root UL
+			var dataOpts = $(this).data('sm-options') || null;
+			if (dataOpts) {
+				try {
+					dataOpts = eval('(' + dataOpts + ')');
+				} catch(e) {
+					dataOpts = null;
+					alert('ERROR\n\nSmartMenus jQuery init:\nInvalid "data-sm-options" attribute value syntax.');
+				};
+			}
 			new $.SmartMenus(this, $.extend({}, $.fn.smartmenus.defaults, options, dataOpts));
 		});
 	};


### PR DESCRIPTION
When there are multiple menus on a page they can initalized like this:

        $('.sm').smartmenus();

 However, when invoked this way, all smartmenus are initialized using the data-sm-options attribute of the first menu on the page rather than the data-sm-options on the menu itself. This pull request fixes that.