### PR TITLE
Fix main module name in smartmenus-bootstrap

### DIFF
--- a/src/addons/bootstrap/jquery.smartmenus.bootstrap.js
+++ b/src/addons/bootstrap/jquery.smartmenus.bootstrap.js
@@ -12,7 +12,7 @@
 (function(factory) {
 	if (typeof define === 'function' && define.amd) {
 		// AMD
-		define(['jquery', 'jquery.smartmenus'], factory);
+		define(['jquery', 'smartmenus'], factory);
 	} else if (typeof module === 'object' && typeof module.exports === 'object') {
 		// CommonJS
 		module.exports = factory(require('jquery'));


### PR DESCRIPTION
Proposed fix to bug: #66