### PR TITLE
Remove errors caused by line breaks

### DIFF
--- a/dist/css/sm-clean/mixins/_round-corners-last-item.scss
+++ b/dist/css/sm-clean/mixins/_round-corners-last-item.scss
@@ -5,8 +5,7 @@
 	$selector: $chain + 'a, ' + $chain + '*:not(ul) a, ' + $chain + 'ul';
 	@for $i from 1 through $level {
 		$chain: $chain + $chainable;
-		$selector: $selector + ',
-' + $chain + ' a, ' + $chain + '*:not(ul) a, ' + $chain + ' ul';
+		$selector: $selector + ', ' + $chain + ' a, ' + $chain + '*:not(ul) a, ' + $chain + ' ul';
 	}
 	#{$selector} {
 		border-radius: 0 0 $amount $amount;
@@ -16,8 +15,7 @@
 	$selector: $chain + 'a.highlighted, ' + $chain + '*:not(ul) a.highlighted';
 	@for $i from 1 through $level {
 		$chain: $chain + $chainable;
-		$selector: $selector + ',
-' + $chain + ' a.highlighted, ' + $chain + '*:not(ul) a.highlighted';
+		$selector: $selector + ', ' + $chain + ' a.highlighted, ' + $chain + '*:not(ul) a.highlighted';
 	}
 	#{$selector} {
 		border-radius: 0;


### PR DESCRIPTION
Got this error when use dart-sass

ERROR in ./resources/assets/sass/frontend.scss
Module build failed (from ./node_modules/css-loader/index.js):
ModuleBuildError: Module build failed (from ./node_modules/sass-loader/dist/cjs.js):

                $selector: $selector + ',
                          ^
      Expected '.
  ╷
8 │         $selector: $selector + ',
  │                                  ^
  ╵
  node_modules/smartmenus/dist/css/sm-clean/mixins/_round-corners-last-item.scss 8:28  @import
  node_modules/smartmenus/dist/css/sm-clean/_mixins.scss 2:9                           @import
  node_modules/smartmenus/dist/css/sm-clean/sm-clean.scss 1:9                          @import
  resources/assets/sass/lib.scss 14:9                                                  @import
  stdin 4:9                                                                            root stylesheet
      in /var/www/winshop/node_modules/smartmenus/dist/css/sm-clean/mixins/_round-corners-last-item.scss (line 8, column 28)
    at runLoaders (/var/www/winshop/node_modules/webpack/lib/NormalModule.js:316:20)
    at /var/www/winshop/node_modules/loader-runner/lib/LoaderRunner.js:367:11
    at /var/www/winshop/node_modules/loader-runner/lib/LoaderRunner.js:233:18
    at context.callback (/var/www/winshop/node_modules/loader-runner/lib/LoaderRunner.js:111:13)
    at render (/var/www/winshop/node_modules/sass-loader/dist/index.js:89:7)
    at Function.call$2 (/var/www/winshop/node_modules/sass/sass.dart.js:93417:16)
    at _render_closure1.call$2 (/var/www/winshop/node_modules/sass/sass.dart.js:81775:12)
    at _RootZone.runBinary$3$3 (/var/www/winshop/node_modules/sass/sass.dart.js:27547:18)
    at _FutureListener.handleError$1 (/var/www/winshop/node_modules/sass/sass.dart.js:26096:19)
    at _Future__propagateToListeners_handleError.call$0 (/var/www/winshop/node_modules/sass/sass.dart.js:26394:49)
    at Object._Future__propagateToListeners (/var/www/winshop/node_modules/sass/sass.dart.js:4541:77)
    at _Future._completeError$2 (/var/www/winshop/node_modules/sass/sass.dart.js:26226:9)
    at _AsyncAwaitCompleter.completeError$2 (/var/www/winshop/node_modules/sass/sass.dart.js:25880:12)
    at Object._asyncRethrow (/var/www/winshop/node_modules/sass/sass.dart.js:4340:17)
    at /var/www/winshop/node_modules/sass/sass.dart.js:12863:20
    at _wrapJsFunctionForAsync_closure.$protected (/var/www/winshop/node_modules/sass/sass.dart.js:4365:15)
    at _wrapJsFunctionForAsync_closure.call$2 (/var/www/winshop/node_modules/sass/sass.dart.js:25901:12)
    at _awaitOnObject_closure0.call$2 (/var/www/winshop/node_modules/sass/sass.dart.js:25893:25)
    at _RootZone.runBinary$3$3 (/var/www/winshop/node_modules/sass/sass.dart.js:27547:18)
    at _FutureListener.handleError$1 (/var/www/winshop/node_modules/sass/sass.dart.js:26096:19)
    at _Future__propagateToListeners_handleError.call$0 (/var/www/winshop/node_modules/sass/sass.dart.js:26394:49)
    at Object._Future__propagateToListeners (/var/www/winshop/node_modules/sass/sass.dart.js:4541:77)
    at _Future._completeError$2 (/var/www/winshop/node_modules/sass/sass.dart.js:26226:9)
    at _AsyncAwaitCompleter.completeError$2 (/var/www/winshop/node_modules/sass/sass.dart.js:25880:12)
    at Object._asyncRethrow (/var/www/winshop/node_modules/sass/sass.dart.js:4340:17)
    at /var/www/winshop/node_modules/sass/sass.dart.js:18181:20
    at _wrapJsFunctionForAsync_closure.$protected (/var/www/winshop/node_modules/sass/sass.dart.js:4365:15)
    at _wrapJsFunctionForAsync_closure.call$2 (/var/www/winshop/node_modules/sass/sass.dart.js:25901:12)
    at _awaitOnObject_closure0.call$2 (/var/www/winshop/node_modules/sass/sass.dart.js:25893:25)
    at _RootZone.runBinary$3$3 (/var/www/winshop/node_modules/sass/sass.dart.js:27547:18)
    at _FutureListener.handleError$1 (/var/www/winshop/node_modules/sass/sass.dart.js:26096:19)
    at _Future__propagateToListeners_handleError.call$0 (/var/www/winshop/node_modules/sass/sass.dart.js:26394:49)
    at Object._Future__propagateToListeners (/var/www/winshop/node_modules/sass/sass.dart.js:4541:77)
    at _Future._completeError$2 (/var/www/winshop/node_modules/sass/sass.dart.js:26226:9)
    at _AsyncAwaitCompleter.completeError$2 (/var/www/winshop/node_modules/sass/sass.dart.js:25880:12)
    at Object._asyncRethrow (/var/www/winshop/node_modules/sass/sass.dart.js:4340:17)
 @ ./resources/assets/sass/frontend.scss