### PR TITLE
feature: use avaliable space if first sub is too large

### DIFF
--- a/packages/smartmenus-configurator/src/App.vue
+++ b/packages/smartmenus-configurator/src/App.vue
@@ -130,6 +130,56 @@ const navbarContentHTML = computed(() => {
             <li class="sm-sub-item"><a class="sm-sub-link sm-disabled" href="#">Disabled</a></li>
           </ul>
         </li>
+        <li class="sm-nav-item"><a class="sm-nav-link sm-sub-toggler" href="#">Long-Sub</a>
+          <ul class="sm-sub">
+            <li class="sm-sub-item"><a class="sm-sub-link" href="#">Link</a></li>
+            <li class="sm-sub-item"><a class="sm-sub-link" href="#">Link</a></li>
+            <li class="sm-sub-item"><a class="sm-sub-link" href="#">Link</a></li>
+            <li class="sm-sub-item"><a class="sm-sub-link" href="#">Link</a></li>
+            <li class="sm-sub-item"><a class="sm-sub-link" href="#">Link</a></li>
+            <li class="sm-sub-item"><a class="sm-sub-link" href="#">Link</a></li>
+            <li class="sm-sub-item"><a class="sm-sub-link" href="#">Link</a></li>
+            <li class="sm-sub-item"><a class="sm-sub-link sm-sub-toggler" href="#">Sub</a>
+              <ul class="sm-sub">
+                <li class="sm-sub-item"><a class="sm-sub-link" href="#">Link</a></li>
+                <li class="sm-sub-item"><a class="sm-sub-link" href="#">Link</a></li>
+                <li class="sm-sub-item"><a class="sm-sub-link sm-sub-toggler" href="#">Sub</a>
+                  <ul class="sm-sub">
+                    <li class="sm-sub-item"><a class="sm-sub-link" href="#">Link</a></li>
+                    <li class="sm-sub-item"><a class="sm-sub-link" href="#">Link</a></li>
+                    <li class="sm-sub-item"><a class="sm-sub-link" href="#">Link</a></li>
+                  </ul>
+                </li>
+                <li class="sm-sub-item"><a class="sm-sub-link" href="#">Link</a></li>
+              </ul>
+            </li>
+            <li class="sm-sub-item"><a class="sm-sub-link" href="#">Link</a></li>
+            <li class="sm-sub-item"><a class="sm-sub-link" href="#">Link</a></li>
+            <li class="sm-sub-item"><a class="sm-sub-link" href="#">Link</a></li>
+            <li class="sm-sub-item"><a class="sm-sub-link" href="#">Link</a></li>
+            <li class="sm-sub-item"><a class="sm-sub-link" href="#">Link</a></li>
+            <li class="sm-sub-item"><a class="sm-sub-link" href="#">Link</a></li>
+            <li class="sm-sub-item"><a class="sm-sub-link" href="#">Link</a></li>
+            <li class="sm-sub-item"><a class="sm-sub-link sm-sub-toggler" href="#">Long-Sub</a>
+              <ul class="sm-sub">
+                <li class="sm-sub-item"><a class="sm-sub-link" href="#">Link</a></li>
+                <li class="sm-sub-item"><a class="sm-sub-link" href="#">Link</a></li>
+                <li class="sm-sub-item"><a class="sm-sub-link" href="#">Link</a></li>
+                <li class="sm-sub-item"><a class="sm-sub-link" href="#">Link</a></li>
+                <li class="sm-sub-item"><a class="sm-sub-link" href="#">Link</a></li>
+                <li class="sm-sub-item"><a class="sm-sub-link" href="#">Link</a></li>
+                <li class="sm-sub-item"><a class="sm-sub-link" href="#">Link</a></li>
+                <li class="sm-sub-item"><a class="sm-sub-link" href="#">Link</a></li>
+                <li class="sm-sub-item"><a class="sm-sub-link" href="#">Link</a></li>
+                <li class="sm-sub-item"><a class="sm-sub-link" href="#">Link</a></li>
+                <li class="sm-sub-item"><a class="sm-sub-link" href="#">Link</a></li>
+              </ul>
+            </li>
+            <li class="sm-sub-item"><a class="sm-sub-link" href="#">Link</a></li>
+            <li class="sm-sub-item-separator"></li>
+            <li class="sm-sub-item"><a class="sm-sub-link sm-disabled" href="#">Disabled</a></li>
+          </ul>
+        </li>
         <li class="sm-nav-item"><a class="sm-nav-link" href="#">Link</a></li>
         <li class="sm-nav-item"><a class="sm-nav-link" href="#">Link</a></li>
         <li class="sm-nav-item"><a class="sm-nav-link sm-nav-link--split" href="#">Link</a><button class="sm-nav-link sm-nav-link--split sm-sub-toggler" aria-label="Toggle sub menu"></button>

--- a/packages/smartmenus/src/js/index.js
+++ b/packages/smartmenus/src/js/index.js
@@ -980,19 +980,24 @@ class SmartMenus {
         x = -parentItemX
       }
 
-      if (!horizontalParent) {
-        if (subHeight < viewportHeight) {
-          if (parentItemY + y + subHeight > viewportHeight) {
-            // Align against the opposite edge of the viewport
-            y = viewportHeight - subHeight - parentItemY
-          } else if (parentItemY + y < 0) {
-            // Align against the same edge of the viewport
-            y = -parentItemY
-          }
-        } else {
-          // If the sub cannot fit inside the viewport, align it against the top edge of the viewport
-          y = downToUp ? viewportHeight - subHeight - parentItemY : -parentItemY
+      if (horizontalParent) {
+        const overHang = subHeight - (viewportHeight - (parentItemY + y))
+        if (overHang > 0) {
+          const liftBy = Math.max(y - overHang, -parentItemY) // at most lift to edge
+          x = parentItemWidth // align sub to the side
+          y = liftBy // lift sub
         }
+      } else if (subHeight < viewportHeight) {
+        if (parentItemY + y + subHeight > viewportHeight) {
+          // Align against the opposite edge of the viewport
+          y = viewportHeight - subHeight - parentItemY
+        } else if (parentItemY + y < 0) {
+          // Align against the same edge of the viewport
+          y = -parentItemY
+        }
+      } else {
+        // If the sub cannot fit inside the viewport, align it against the top edge of the viewport
+        y = downToUp ? viewportHeight - subHeight - parentItemY : -parentItemY
       }
     }
 


### PR DESCRIPTION
hi,

I would need something like this, do you want it upstreamed or should I maintain this separately ?

Feedback is also welcome.

Regards

-- 

this shifts long subs sideways and up/down into available space (is easily visible in the configurator by using a small  `vh` and opening "Long-Sub")

EDIT: I should add, this is in response to `scroll` not being implemented (yet?) in sm2.0 (in sm1.0 there was an up/down icon which shifted the items), if `scroll` gets implemented (I could help a bit) - this PR may be unnecessary